### PR TITLE
feat #7: 사용자 로그인, 로그아웃 API 구현 및 JWT 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/wanted/spendtracker/config/RedisConfig.java
+++ b/src/main/java/com/wanted/spendtracker/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.wanted.spendtracker.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        // setKeySerializer, setValueSerializer 설정
+        // redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/spendtracker/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.wanted.spendtracker.config;
 
+import com.wanted.spendtracker.infrastructure.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,26 +10,36 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final AccessDeniedHandler accessDeniedHandler;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
-                // disable session
-                .sessionManagement((sessionManagement) ->
-                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/api/**").permitAll()
+                        .anyRequest().authenticated()
                 )
 
-                .authorizeHttpRequests((authorizeRequests) ->
-                        authorizeRequests
-                                .requestMatchers("/api/members/**").permitAll()
-                                .anyRequest().authenticated()
+                // disable session
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/wanted/spendtracker/controller/AuthController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.wanted.spendtracker.controller;
+
+import com.wanted.spendtracker.dto.request.TokenCreateRequest;
+import com.wanted.spendtracker.dto.response.TokenCreateResponse;
+import com.wanted.spendtracker.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/api/auth/login")
+    public ResponseEntity<TokenCreateResponse> login(@RequestBody @Valid TokenCreateRequest tokenCreateRequest) {
+        TokenCreateResponse tokenCreateResponse = authService.login(tokenCreateRequest);
+        return ResponseEntity.ok().body(tokenCreateResponse);
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/controller/AuthController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.wanted.spendtracker.controller;
 
+import com.wanted.spendtracker.domain.MemberAdapter;
 import com.wanted.spendtracker.dto.request.TokenCreateRequest;
 import com.wanted.spendtracker.dto.response.TokenCreateResponse;
+import com.wanted.spendtracker.infrastructure.JwtTokenProvider;
 import com.wanted.spendtracker.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,11 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/api/auth/login")
     public ResponseEntity<TokenCreateResponse> login(@RequestBody @Valid TokenCreateRequest tokenCreateRequest) {
         TokenCreateResponse tokenCreateResponse = authService.login(tokenCreateRequest);
         return ResponseEntity.ok().body(tokenCreateResponse);
+    }
+
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal MemberAdapter memberAdapter, HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        authService.logout(memberAdapter, accessToken);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/domain/MemberAdapter.java
+++ b/src/main/java/com/wanted/spendtracker/domain/MemberAdapter.java
@@ -1,0 +1,65 @@
+package com.wanted.spendtracker.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class MemberAdapter implements UserDetails {
+
+    private final Member member;
+
+    @Builder
+    private MemberAdapter(Member member) {
+        this.member = member;
+    }
+
+    public static MemberAdapter from(Member member) {
+        return MemberAdapter.builder()
+                .member(member)
+                .build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().name()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getAccountName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/wanted/spendtracker/dto/request/TokenCreateRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/TokenCreateRequest.java
@@ -1,0 +1,19 @@
+package com.wanted.spendtracker.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenCreateRequest {
+
+    @NotBlank(message = "AUTH_ACCOUNT_NAME_BLANK")
+    @Size(min = 2, max = 20, message = "AUTH_ACCOUNT_NAME_LENGTH_INVALID")
+    private String accountName;
+
+    @NotBlank(message = "AUTH_PASSWORD_BLANK")
+    private String password;
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/CustomErrorResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/CustomErrorResponse.java
@@ -7,18 +7,18 @@ import lombok.Getter;
 @Getter
 public class CustomErrorResponse {
 
-    private final String errorCode;
+    private final String code;
     private final String message;
 
     @Builder
-    private CustomErrorResponse(String errorCode, String message) {
-        this.errorCode = errorCode;
+    private CustomErrorResponse(String code, String message) {
+        this.code = code;
         this.message = message;
     }
 
     public static CustomErrorResponse of(ErrorCode errorCode) {
         return CustomErrorResponse.builder()
-                .errorCode(errorCode.name())
+                .code(errorCode.name())
                 .message(errorCode.getMessage())
                 .build();
     }

--- a/src/main/java/com/wanted/spendtracker/dto/response/TokenCreateResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/TokenCreateResponse.java
@@ -1,0 +1,16 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class TokenCreateResponse {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/AccessDeniedHandlerImpl.java
+++ b/src/main/java/com/wanted/spendtracker/exception/AccessDeniedHandlerImpl.java
@@ -1,0 +1,43 @@
+package com.wanted.spendtracker.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.spendtracker.dto.response.CustomErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.server.Encoding;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.wanted.spendtracker.exception.ErrorCode.AUTH_AUTHORIZATION_FAILED;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error(accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage());
+
+        CustomErrorResponse customErrorResponse = CustomErrorResponse.of(AUTH_AUTHORIZATION_FAILED);
+        String responseBody = objectMapper.writeValueAsString(customErrorResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(Encoding.DEFAULT_CHARSET.name());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.getWriter().write(responseBody);
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/wanted/spendtracker/exception/AuthenticationEntryPointImpl.java
@@ -1,0 +1,43 @@
+package com.wanted.spendtracker.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.spendtracker.dto.response.CustomErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.server.Encoding;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.wanted.spendtracker.exception.ErrorCode.AUTH_AUTHENTICATION_FAILED;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        log.error(authException.getClass().getSimpleName(), authException.getMessage());
+
+        CustomErrorResponse customErrorResponse = CustomErrorResponse.of(AUTH_AUTHENTICATION_FAILED);
+        String responseBody = objectMapper.writeValueAsString(customErrorResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding(Encoding.DEFAULT_CHARSET.name());
+        response.getWriter().write(responseBody);
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
@@ -1,10 +1,10 @@
 package com.wanted.spendtracker.exception;
 
-import static org.springframework.http.HttpStatus.*;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
 
 @AllArgsConstructor
 @Getter
@@ -21,6 +21,18 @@ public enum ErrorCode {
     MEMBER_ACCOUNT_NAME_DUPLICATED("이미 같은 이름의 계정이 존재합니다", BAD_REQUEST),
     MEMBER_ACCOUNT_NAME_LENGTH_INVALID("계정 이름은 최소 2자 이상 최대 20자 이하이어야 합니다", BAD_REQUEST),
     MEMBER_ACCOUNT_NAME_BLANK("계정 이름은 공백일 수 없습니다.", BAD_REQUEST),
+
+    AUTH_AUTHENTICATION_FAILED("인증에 실패하셨습니다.", UNAUTHORIZED),
+    AUTH_AUTHORIZATION_FAILED("권한이 없습니다.", FORBIDDEN),
+    AUTH_ACCOUNT_NAME_BLANK("계정 이름은 공백일 수 없습니다.", BAD_REQUEST),
+    AUTH_ACCOUNT_NAME_LENGTH_INVALID("계정 이름은 최소 2자 이상 최대 20자 이하이어야 합니다", BAD_REQUEST),
+    AUTH_JWT_CLAIMS_EMPTY("JWT claims 문자열이 비어 있습니다.", UNAUTHORIZED),
+    AUTH_JWT_EXPIRED("만료된 토큰입니다.", UNAUTHORIZED),
+    AUTH_JWT_INVALID("잘못된 토큰입니다.", UNAUTHORIZED),
+    AUTH_JWT_UNPRIVILEGED("권한이 없는 토큰입니다.", FORBIDDEN),
+    AUTH_JWT_UNSUPPORTED("지원되지 않는 토큰입니다.", UNAUTHORIZED),
+    AUTH_MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", BAD_REQUEST),
+    AUTH_PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", BAD_REQUEST),
 
     ;
 

--- a/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
@@ -7,21 +7,19 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 import static com.wanted.spendtracker.exception.ErrorCode.AUTH_JWT_UNPRIVILEGED;
 import static com.wanted.spendtracker.infrastructure.JwtTokenProvider.CLAIMS_AUTH;
-import static com.wanted.spendtracker.infrastructure.JwtTokenProvider.GRANTTYPE_BEARER;
 
 @Component
 @RequiredArgsConstructor
@@ -29,26 +27,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String token = resolveToken(request);
-        if (token != null) {
-            jwtTokenProvider.validateToken(token);
-            Authentication authentication = getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        String token = jwtTokenProvider.resolveToken(request);
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            if (redisTemplate.opsForValue().get(token) == null) {
+                Authentication authentication = getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
-        filterChain.doFilter(request, response);
-    }
 
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(GRANTTYPE_BEARER)) {
-            return bearerToken.substring(GRANTTYPE_BEARER.length() + 1);
-        }
-        return null;
+        filterChain.doFilter(request, response);
     }
 
     private Authentication getAuthentication(String accessToken) {
@@ -59,4 +52,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
         return new UsernamePasswordAuthenticationToken(userDetails, accessToken, userDetails.getAuthorities());
     }
+
 }

--- a/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.wanted.spendtracker.infrastructure;
+
+import com.wanted.spendtracker.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.wanted.spendtracker.exception.ErrorCode.AUTH_JWT_UNPRIVILEGED;
+import static com.wanted.spendtracker.infrastructure.JwtTokenProvider.CLAIMS_AUTH;
+import static com.wanted.spendtracker.infrastructure.JwtTokenProvider.GRANTTYPE_BEARER;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null) {
+            jwtTokenProvider.validateToken(token);
+            Authentication authentication = getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(GRANTTYPE_BEARER)) {
+            return bearerToken.substring(GRANTTYPE_BEARER.length() + 1);
+        }
+        return null;
+    }
+
+    private Authentication getAuthentication(String accessToken) {
+        Claims claims = jwtTokenProvider.parseClaims(accessToken);
+        if (claims.get(CLAIMS_AUTH) == null) {
+            throw new CustomException(AUTH_JWT_UNPRIVILEGED);
+        }
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, accessToken, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/wanted/spendtracker/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/spendtracker/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,95 @@
+package com.wanted.spendtracker.infrastructure;
+
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.response.TokenCreateResponse;
+import com.wanted.spendtracker.exception.CustomException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+import static com.wanted.spendtracker.exception.ErrorCode.*;
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    public static final String CLAIMS_AUTH = "auth";
+    public static final String GRANTTYPE_BEARER = "Bearer";
+
+    private final long expirationTimeMillis;
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${security.jwt.secret-key}") final String secretKey,
+                            @Value("${security.jwt.expire-period}") final Long expirationTimeMillis) {
+        byte[] secretByteKey = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(secretByteKey);
+        this.expirationTimeMillis = expirationTimeMillis;
+    }
+
+    public TokenCreateResponse generateToken(final Member member) {
+        final String accessToken = generateAccessToken(member);
+        final String refreshToken = generateRefreshToken();
+        return TokenCreateResponse.builder()
+                .grantType(GRANTTYPE_BEARER)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public void validateToken(final String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token).getBody();
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new CustomException(AUTH_JWT_INVALID, e);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(AUTH_JWT_EXPIRED, e);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(AUTH_JWT_UNSUPPORTED, e);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(AUTH_JWT_CLAIMS_EMPTY, e);
+        }
+    }
+
+    public Claims parseClaims(final String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    private String generateAccessToken(final Member member) {
+        final Date expiration = new Date(System.currentTimeMillis() + expirationTimeMillis);
+        return Jwts.builder()
+                .setSubject(member.getAccountName())
+                .claim(CLAIMS_AUTH, member.getRole())
+                .setExpiration(expiration)
+                .signWith(key, HS256)
+                .compact();
+    }
+
+    private String generateRefreshToken() {
+        final Date expiration = new Date(System.currentTimeMillis() + expirationTimeMillis * 24 * 7);
+        return Jwts.builder()
+                .setExpiration(expiration)
+                .signWith(key, HS256)
+                .compact();
+    }
+
+}
+

--- a/src/main/java/com/wanted/spendtracker/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/spendtracker/infrastructure/JwtTokenProvider.java
@@ -58,6 +58,7 @@ public class JwtTokenProvider {
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(token).getBody();
+            return true;
         } catch (SecurityException | MalformedJwtException e) {
             throw new CustomException(AUTH_JWT_INVALID, e);
         } catch (ExpiredJwtException e) {
@@ -67,7 +68,6 @@ public class JwtTokenProvider {
         } catch (IllegalArgumentException e) {
             throw new CustomException(AUTH_JWT_CLAIMS_EMPTY, e);
         }
-        return true;
     }
 
     public Claims parseClaims(final String accessToken) {

--- a/src/main/java/com/wanted/spendtracker/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package com.wanted.spendtracker.repository;
 import com.wanted.spendtracker.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByAccountName(String accountName);
+
 }

--- a/src/main/java/com/wanted/spendtracker/service/AuthService.java
+++ b/src/main/java/com/wanted/spendtracker/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
         if (redisTemplate.opsForValue().get(accountName) != null) {
             redisTemplate.delete(accountName);
         }
-        redisTemplate.opsForValue().set(accountName, "logout", Duration.ofMillis(expiration));
+        redisTemplate.opsForValue().set(accessToken, "logout", Duration.ofMillis(expiration));
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/service/AuthService.java
+++ b/src/main/java/com/wanted/spendtracker/service/AuthService.java
@@ -1,0 +1,32 @@
+package com.wanted.spendtracker.service;
+
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.TokenCreateRequest;
+import com.wanted.spendtracker.dto.response.TokenCreateResponse;
+import com.wanted.spendtracker.infrastructure.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public TokenCreateResponse login(TokenCreateRequest tokenCreateRequest) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                tokenCreateRequest.getAccountName(),
+                tokenCreateRequest.getPassword()
+        );
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        Member member = ((MemberAdapter) authentication.getPrincipal()).getMember();
+        return jwtTokenProvider.generateToken(member);
+    }
+}

--- a/src/main/java/com/wanted/spendtracker/service/AuthService.java
+++ b/src/main/java/com/wanted/spendtracker/service/AuthService.java
@@ -6,11 +6,14 @@ import com.wanted.spendtracker.dto.request.TokenCreateRequest;
 import com.wanted.spendtracker.dto.response.TokenCreateResponse;
 import com.wanted.spendtracker.infrastructure.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class AuthService {
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional(readOnly = true)
     public TokenCreateResponse login(TokenCreateRequest tokenCreateRequest) {
@@ -29,4 +33,14 @@ public class AuthService {
         Member member = ((MemberAdapter) authentication.getPrincipal()).getMember();
         return jwtTokenProvider.generateToken(member);
     }
+
+    public void logout(MemberAdapter memberAdapter, String accessToken) {
+        Long expiration = jwtTokenProvider.getExpiration(accessToken);
+        String accountName = memberAdapter.getUsername();
+        if (redisTemplate.opsForValue().get(accountName) != null) {
+            redisTemplate.delete(accountName);
+        }
+        redisTemplate.opsForValue().set(accountName, "logout", Duration.ofMillis(expiration));
+    }
+
 }

--- a/src/main/java/com/wanted/spendtracker/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/wanted/spendtracker/service/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package com.wanted.spendtracker.service;
+
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.exception.CustomException;
+import com.wanted.spendtracker.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import static com.wanted.spendtracker.exception.ErrorCode.AUTH_MEMBER_NOT_EXISTS;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String accountName) throws UsernameNotFoundException {
+        Member member = memberRepository.findByAccountName(accountName)
+                .orElseThrow(() -> new CustomException(AUTH_MEMBER_NOT_EXISTS));
+        return MemberAdapter.from(member);
+    }
+
+}

--- a/src/test/java/com/wanted/spendtracker/controller/AuthControllerTest.java
+++ b/src/test/java/com/wanted/spendtracker/controller/AuthControllerTest.java
@@ -1,0 +1,140 @@
+package com.wanted.spendtracker.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.request.MemberSignUpRequest;
+import com.wanted.spendtracker.dto.request.TokenCreateRequest;
+import com.wanted.spendtracker.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.wanted.spendtracker.TestConstants.*;
+import static com.wanted.spendtracker.exception.ErrorCode.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        MemberSignUpRequest memberSignUpRequest = MemberSignUpRequest.builder()
+                .accountName(ACCOUNT_NAME)
+                .password(PASSWORD)
+                .build();
+        memberRepository.save(Member.of(memberSignUpRequest, passwordEncoder.encode(memberSignUpRequest.getPassword())));
+    }
+
+    @Test
+    @DisplayName("로그인 요청 시 jwt를 발급받는다.")
+    void login() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .accountName(ACCOUNT_NAME)
+                .password(PASSWORD)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.grantType").value("Bearer"))
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists());
+    }
+
+    @Test
+    @DisplayName("잘못된 계정명으로 로그인할 수 없다.")
+    void login_invalidAccountName() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .accountName(ACCOUNT_NAME + "t")
+                .password(PASSWORD)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(AUTH_MEMBER_NOT_EXISTS.name()));
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인할 수 없다.")
+    void login_invalidPassword() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .accountName(ACCOUNT_NAME)
+                .password(PASSWORD + "t")
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(AUTH_AUTHENTICATION_FAILED.name()));
+    }
+
+    @Test
+    @DisplayName("계정 이름이 공백이면 로그인할 수 없다.")
+    void login_emptyAccountName() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .accountName(BLANK)
+                .password(PASSWORD)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(AUTH_ACCOUNT_NAME_BLANK.name()));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 공백이면 로그인할 수 없다.")
+    void login_emptyPassword() throws Exception {
+        //given
+        TokenCreateRequest tokenCreateRequest = TokenCreateRequest.builder()
+                .accountName(ACCOUNT_NAME)
+                .password(BLANK)
+                .build();
+
+        //when then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tokenCreateRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(AUTH_PASSWORD_BLANK.name()));
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #7


## 🔨 작업 내용

1. JWT 관련 설정

2. 사용자 로그인 API
- accessToken
  - 만료시간 1시간으로 설정하여 발급
- refreshToken
  - 만료시간 1주일으로 설정하여 발급
  - 발급 시 redis 에 저장
3. 사용자 로그아웃 API
- redis에서 해당 사용자의 refreshToken 을 삭제
- 이후 로그아웃 여부 확인을 위해 로그아웃한 사용자 블랙리스트 설정
  - redis에 `key(accessToken) : value("logout") ` 으로 저장
  - JwtAuthenticationFilter 에서 해당 검증 로직 추가
## 💬 기타 사항

- 