### PR TITLE
feat #9: 예산설정 API 구현

### DIFF
--- a/src/main/java/com/wanted/spendtracker/controller/BudgetController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/BudgetController.java
@@ -1,9 +1,27 @@
 package com.wanted.spendtracker.controller;
 
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.BudgetSetRequest;
+import com.wanted.spendtracker.service.BudgetService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @PostMapping("/api/budgets")
+    public ResponseEntity<Void> setBudget(@AuthenticationPrincipal MemberAdapter memberAdapter, @Valid @RequestBody BudgetSetRequest budgetSetRequest) {
+        budgetService.setBudget(memberAdapter, budgetSetRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Budget.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Budget.java
@@ -2,6 +2,7 @@ package com.wanted.spendtracker.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Budget extends BaseTimeEntity{
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -17,9 +19,30 @@ public class Budget extends BaseTimeEntity{
     private Long amount;
 
     @Column(nullable = false)
-    private int month;
+    private Integer month;
 
-    @Column(nullable = false)
-    private int year;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "catefory_id", nullable = false)
+    private Category category;
+
+    @Builder
+    private Budget(Long amount, int month, Member member, Category category) {
+        this.amount = amount;
+        this.month = month;
+        this.member = member;
+        this.category = category;
+    }
+
+    public static Budget of(Long amount, Integer month, Member member, Category category) {
+        return Budget.builder()
+                .amount(amount)
+                .month(month)
+                .member(member)
+                .category(category).build();
+    }
 
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Category.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Category.java
@@ -5,6 +5,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,5 +19,8 @@ public class Category {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    @OneToMany(mappedBy = "category")
+    private List<Budget> budgets = new ArrayList<>();
 
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Member.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Member.java
@@ -7,6 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.wanted.spendtracker.domain.Role.ROLE_USER;
 
 @Getter
@@ -27,6 +30,9 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Budget> budgets = new ArrayList<>();
 
     @Builder
     private Member(String accountName, String password, Role role) {

--- a/src/main/java/com/wanted/spendtracker/dto/request/BudgetSetRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/BudgetSetRequest.java
@@ -1,0 +1,38 @@
+package com.wanted.spendtracker.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BudgetSetRequest {
+
+    @Valid
+    @NotNull(message = "BUDGET_REQUEST_EMPTY")
+    List<BudgetRequest> budgetRequestList;
+
+    @Getter
+    public static class BudgetRequest {
+
+        @NotNull(message = "BUDGET_MONTH_EMPTY")
+        @Min(value = 1, message = "BUDGET_MONTH_INVALID")
+        @Max(value = 12, message = "BUDGET_MONTH_INVALID")
+        private Integer month;
+
+        @NotNull(message = "BUDGET_CATEGORY_NOT_EXISTS")
+        private Long categoryId;
+
+        @NotNull(message = "BUDGET_AMOUNT_EMPTY")
+        @Min(value = 0, message = "BUDGET_AMOUNT_INVALID")
+        private Long amount;
+
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
@@ -34,6 +34,12 @@ public enum ErrorCode {
     AUTH_MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", BAD_REQUEST),
     AUTH_PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", BAD_REQUEST),
 
+    BUDGET_MONTH_EMPTY("예산 월이 존재하지 않습니다.", BAD_REQUEST),
+    BUDGET_MONTH_INVALID("예산 월이 유효하지 않습니다.", BAD_REQUEST),
+    BUDGET_CATEGORY_NOT_EXISTS("카테고리가 존재하지 않습니다.", BAD_REQUEST),
+    BUDGET_AMOUNT_EMPTY("예산 금액이 설정되지 않았습니다.", BAD_REQUEST),
+    BUDGET_AMOUNT_INVALID("예산 금액이 유효하지 않습니다.", BAD_REQUEST),
+    BUDGET_REQUEST_EMPTY("예산 금액 요청이 존재하지 않습니다.", BAD_REQUEST),
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/spendtracker/service/BudgetService.java
+++ b/src/main/java/com/wanted/spendtracker/service/BudgetService.java
@@ -1,9 +1,39 @@
 package com.wanted.spendtracker.service;
 
+import com.wanted.spendtracker.domain.Budget;
+import com.wanted.spendtracker.domain.Category;
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.BudgetSetRequest;
+import com.wanted.spendtracker.exception.CustomException;
+import com.wanted.spendtracker.repository.BudgetRepository;
+import com.wanted.spendtracker.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.wanted.spendtracker.exception.ErrorCode.BUDGET_CATEGORY_NOT_EXISTS;
 
 @Service
 @RequiredArgsConstructor
 public class BudgetService {
+
+    private final BudgetRepository budgetRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public void setBudget(MemberAdapter memberAdapter, BudgetSetRequest budgetSetRequest) {
+        Member member = memberAdapter.getMember();
+        List<BudgetSetRequest.BudgetRequest> budgetRequests = budgetSetRequest.getBudgetRequestList();
+        for (BudgetSetRequest.BudgetRequest budgetRequest : budgetRequests) {
+            Category category = categoryRepository.findById(budgetRequest.getCategoryId())
+                    .orElseThrow(() -> new CustomException(BUDGET_CATEGORY_NOT_EXISTS));
+            Budget budget = Budget.of(budgetRequest.getAmount(), budgetRequest.getMonth(), member, category);
+            budgetRepository.save(budget);
+        }
+
+    }
+
 }


### PR DESCRIPTION
## 📃 설명

- resolves #9
- 

## 🔨 작업 내용

1. 월별 예산 설정을 위해 예산 월, 카테고리Id, 금액을 요청 받아 저장한다.
2. 요청 받는 값의 검증 로직을 거치고 예외 처리한다.

## 💬 기타 사항

- 