### PR TITLE
fix #20: 로그아웃 사용자가 인증이 필요한 서비스 사용하려할 때 예외처리 추가

### DIFF
--- a/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/spendtracker/infrastructure/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.wanted.spendtracker.exception.ErrorCode.AUTH_AUTHENTICATION_FAILED;
 import static com.wanted.spendtracker.exception.ErrorCode.AUTH_JWT_UNPRIVILEGED;
 import static com.wanted.spendtracker.infrastructure.JwtTokenProvider.CLAIMS_AUTH;
 
@@ -38,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (redisTemplate.opsForValue().get(token) == null) {
                 Authentication authentication = getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+            } else throw new CustomException(AUTH_AUTHENTICATION_FAILED);
         }
 
         filterChain.doFilter(request, response);

--- a/src/test/java/com/wanted/spendtracker/controller/MemberControllerTest.java
+++ b/src/test/java/com/wanted/spendtracker/controller/MemberControllerTest.java
@@ -74,7 +74,7 @@ class MemberControllerTest {
                         .content(content))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.errorCode").value(errorCode.name()))
+                .andExpect(jsonPath("$.code").value(errorCode.name()))
                 .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
                 .andDo(print())
                 .andReturn();


### PR DESCRIPTION

## 📃 설명

- resolves #20
- 

## 🔨 작업 내용

1. JwtAuthenticationFilter 에 예외처리르 추가하여 로그아웃한 사용자가 인증이 필요한 서비스 사용 요청 시 401에러를 반환

## 💬 기타 사항

- 