### PR TITLE
feat #11: 지출 생성, 수정, 삭제, 상세조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
@@ -1,9 +1,56 @@
 package com.wanted.spendtracker.controller;
 
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
+import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
+import com.wanted.spendtracker.dto.response.ExpensesResponse;
+import com.wanted.spendtracker.service.ExpensesService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
 public class ExpensesController {
+
+    private final ExpensesService expensesService;
+
+    @PostMapping("/api/expenses")
+    public ResponseEntity<Void> createExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                               @Valid @RequestBody ExpensesCreateRequest expensesCreateRequest) {
+        Member member = memberAdapter.getMember();
+        Long expensesId = expensesService.createExpenses(member, expensesCreateRequest);
+        return ResponseEntity.created(URI.create("/api/expenses/" + expensesId)).build();
+    }
+
+    @PatchMapping ("/api/expenses/{expensesId}")
+    public ResponseEntity<Void> updateExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                           @PathVariable Long expensesId,
+                                                           @Valid @RequestBody ExpensesUpdateRequest expensesUpdateRequest) {
+        Member member = memberAdapter.getMember();
+        expensesService.updateExpenses(member, expensesId, expensesUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping ("/api/expenses/{expensesId}")
+    public ResponseEntity<ExpensesResponse> getExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                        @PathVariable Long expensesId) {
+        Member member = memberAdapter.getMember();
+        ExpensesResponse expensesResponse = expensesService.getExpenses(member, expensesId);
+        return ResponseEntity.ok().body(expensesResponse);
+    }
+
+    @DeleteMapping ("/api/expenses/{expensesId}")
+    public ResponseEntity<Void> deleteExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                        @PathVariable Long expensesId) {
+        Member member = memberAdapter.getMember();
+        expensesService.deleteExpenses(member, expensesId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Category.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Category.java
@@ -23,4 +23,7 @@ public class Category {
     @OneToMany(mappedBy = "category")
     private List<Budget> budgets = new ArrayList<>();
 
+    @OneToMany(mappedBy = "category")
+    private List<Expenses> expenses = new ArrayList<>();
+
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Expenses.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Expenses.java
@@ -1,9 +1,13 @@
 package com.wanted.spendtracker.domain;
 
+import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
+import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 
@@ -27,6 +31,65 @@ public class Expenses extends BaseTimeEntity {
 
     //전체 지출 합계 시 포함 여부
     @Column(nullable = false)
-    private boolean excludeFromTotalAmount = false;
+    private Boolean excludeFromTotalAmount = false;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Builder
+    private Expenses(LocalDate date, Long amount, String memo, boolean excludeFromTotalAmount, Member member, Category category) {
+        this.date = date;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotalAmount = excludeFromTotalAmount;
+        this.member = member;
+        this.category = category;
+    }
+
+    public static Expenses of(ExpensesCreateRequest expensesCreateRequest, Member member, Category category) {
+        return Expenses.builder()
+                .date(expensesCreateRequest.getDate())
+                .amount(expensesCreateRequest.getAmount())
+                .memo(expensesCreateRequest.getMemo())
+                .excludeFromTotalAmount(expensesCreateRequest.getExcludeFromTotalAmount())
+                .member(member)
+                .category(category).build();
+    }
+
+    public void update(ExpensesUpdateRequest expensesUpdateRequest) {
+        updateDate(expensesUpdateRequest.getDate());
+        updateAmount(expensesUpdateRequest.getAmount());
+        updateMemo(expensesUpdateRequest.getMemo());
+        updateExcludeFromTotalAmount(expensesUpdateRequest.getExcludeFromTotalAmount());
+    }
+
+    private void updateDate(LocalDate date) {
+        if (date != null) {
+            this.date = date;
+        }
+    }
+
+    private void updateAmount(Long amount) {
+        if (amount != null) {
+            this.amount = amount;
+        }
+    }
+
+    private void updateMemo(String memo) {
+        if (StringUtils.hasText(memo)) {
+            this.memo = memo;
+        }
+    }
+
+    private void updateExcludeFromTotalAmount(Boolean excludeFromTotalAmount) {
+        if (excludeFromTotalAmount != null) {
+            this.excludeFromTotalAmount = excludeFromTotalAmount;
+        }
+    }
 
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Member.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Member.java
@@ -34,6 +34,9 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Budget> budgets = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Expenses> expenses = new ArrayList<>();
+
     @Builder
     private Member(String accountName, String password, Role role) {
         this.accountName = accountName;

--- a/src/main/java/com/wanted/spendtracker/dto/request/ExpensesCreateRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/ExpensesCreateRequest.java
@@ -1,0 +1,44 @@
+package com.wanted.spendtracker.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpensesCreateRequest {
+
+    @NotNull(message = "CATEGORY_NOT_EXISTS")
+    private Long categoryId;
+
+    @NotNull(message = "EXPENSES_DATE_EMPTY")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate date;
+
+    @NotNull(message = "EXPENSES_AMOUNT_EMPTY")
+    @Min(value = 0, message = "EXPENSES_AMOUNT_INVALID")
+    private Long amount;
+
+    private String memo;
+
+    @NotNull(message = "EXPENSES_EXCLUDE_FROM_TOTAL_AMOUNT_EMPTY")
+    private Boolean excludeFromTotalAmount;
+
+    @Builder
+    private ExpensesCreateRequest(Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
+        this.categoryId = categoryId;
+        this.date = date;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotalAmount = excludeFromTotalAmount;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/request/ExpensesUpdateRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/ExpensesUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.wanted.spendtracker.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpensesUpdateRequest {
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate date;
+
+    @Min(value = 0, message = "EXPENSES_AMOUNT_INVALID")
+    private Long amount;
+
+    private String memo;
+
+    private Boolean excludeFromTotalAmount;
+
+    @Builder
+    private ExpensesUpdateRequest(LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
+        this.date = date;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotalAmount = excludeFromTotalAmount;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesResponse.java
@@ -1,0 +1,44 @@
+package com.wanted.spendtracker.dto.response;
+
+import com.wanted.spendtracker.domain.Expenses;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class ExpensesResponse {
+
+    private final Long memberId;
+
+    private final Long categoryId;
+
+    private final LocalDate date;
+
+    private final Long amount;
+
+    private final String memo;
+
+    private final Boolean excludeFromTotalAmount;
+
+    @Builder
+    private ExpensesResponse(Long memberId, Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.date = date;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeFromTotalAmount = excludeFromTotalAmount;
+    }
+
+    public static ExpensesResponse from(Expenses expenses) {
+        return ExpensesResponse.builder()
+                .memberId(expenses.getMember().getId())
+                .categoryId(expenses.getCategory().getId())
+                .date(expenses.getDate())
+                .amount(expenses.getAmount())
+                .memo(expenses.getMemo())
+                .excludeFromTotalAmount(expenses.getExcludeFromTotalAmount()).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     MEMBER_ACCOUNT_NAME_DUPLICATED("이미 같은 이름의 계정이 존재합니다", BAD_REQUEST),
     MEMBER_ACCOUNT_NAME_LENGTH_INVALID("계정 이름은 최소 2자 이상 최대 20자 이하이어야 합니다", BAD_REQUEST),
     MEMBER_ACCOUNT_NAME_BLANK("계정 이름은 공백일 수 없습니다.", BAD_REQUEST),
+    MEMBER_NOT_SAME("해당 작성자가 아닙니다.", BAD_REQUEST),
 
     AUTH_AUTHENTICATION_FAILED("인증에 실패하셨습니다.", UNAUTHORIZED),
     AUTH_AUTHORIZATION_FAILED("권한이 없습니다.", FORBIDDEN),
@@ -34,12 +35,20 @@ public enum ErrorCode {
     AUTH_MEMBER_NOT_EXISTS("존재하지 않는 사용자입니다.", BAD_REQUEST),
     AUTH_PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", BAD_REQUEST),
 
+    CATEGORY_NOT_EXISTS("카테고리가 존재하지 않습니다.", BAD_REQUEST),
+
     BUDGET_MONTH_EMPTY("예산 월이 존재하지 않습니다.", BAD_REQUEST),
     BUDGET_MONTH_INVALID("예산 월이 유효하지 않습니다.", BAD_REQUEST),
-    BUDGET_CATEGORY_NOT_EXISTS("카테고리가 존재하지 않습니다.", BAD_REQUEST),
     BUDGET_AMOUNT_EMPTY("예산 금액이 설정되지 않았습니다.", BAD_REQUEST),
     BUDGET_AMOUNT_INVALID("예산 금액이 유효하지 않습니다.", BAD_REQUEST),
     BUDGET_REQUEST_EMPTY("예산 금액 요청이 존재하지 않습니다.", BAD_REQUEST),
+
+    EXPENSES_DATE_EMPTY("지출 날짜가 존재하지 않습니다.", BAD_REQUEST),
+    EXPENSES_EXCLUDE_FROM_TOTAL_AMOUNT_EMPTY("지출 함계 여부가 설정되지 않았습니다", BAD_REQUEST),
+    EXPENSES_AMOUNT_EMPTY("지출 금액이 설정되지 않았습니다.", BAD_REQUEST),
+    EXPENSES_AMOUNT_INVALID("지출 금액이 유효하지 않습니다.", BAD_REQUEST),
+    EXPENSES_NOT_EXISTS("지출 내역이 존재하지 않습니다.", BAD_REQUEST),
+
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/spendtracker/service/BudgetService.java
+++ b/src/main/java/com/wanted/spendtracker/service/BudgetService.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.wanted.spendtracker.exception.ErrorCode.BUDGET_CATEGORY_NOT_EXISTS;
+import static com.wanted.spendtracker.exception.ErrorCode.CATEGORY_NOT_EXISTS;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +29,7 @@ public class BudgetService {
         List<BudgetSetRequest.BudgetRequest> budgetRequests = budgetSetRequest.getBudgetRequestList();
         for (BudgetSetRequest.BudgetRequest budgetRequest : budgetRequests) {
             Category category = categoryRepository.findById(budgetRequest.getCategoryId())
-                    .orElseThrow(() -> new CustomException(BUDGET_CATEGORY_NOT_EXISTS));
+                    .orElseThrow(() -> new CustomException(CATEGORY_NOT_EXISTS));
             Budget budget = Budget.of(budgetRequest.getAmount(), budgetRequest.getMonth(), member, category);
             budgetRepository.save(budget);
         }

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
@@ -1,9 +1,74 @@
 package com.wanted.spendtracker.service;
 
+import com.wanted.spendtracker.domain.Category;
+import com.wanted.spendtracker.domain.Expenses;
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
+import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
+import com.wanted.spendtracker.dto.response.ExpensesResponse;
+import com.wanted.spendtracker.exception.CustomException;
+import com.wanted.spendtracker.exception.ErrorCode;
+import com.wanted.spendtracker.repository.CategoryRepository;
+import com.wanted.spendtracker.repository.ExpensesRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static com.wanted.spendtracker.exception.ErrorCode.CATEGORY_NOT_EXISTS;
+import static com.wanted.spendtracker.exception.ErrorCode.EXPENSES_NOT_EXISTS;
 
 @Service
 @RequiredArgsConstructor
 public class ExpensesService {
+
+    private final ExpensesRepository expensesRepository;
+    private final CategoryRepository categoryRepository;
+
+
+    @Transactional
+    public Long createExpenses(Member member, ExpensesCreateRequest expensesCreateRequest) {
+        Category category = checkCategory(expensesCreateRequest.getCategoryId());
+        Expenses expenses = Expenses.of(expensesCreateRequest, member, category);
+        return expensesRepository.save(expenses).getId();
+    }
+
+    @Transactional
+    public void updateExpenses(Member member, Long expensesId, ExpensesUpdateRequest expensesUpdateRequest) {
+        Expenses expenses = checkExpenses(expensesId);
+        checkMember(member, expenses);
+        expenses.update(expensesUpdateRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public ExpensesResponse getExpenses(Member member, Long expensesId) {
+        Expenses expenses = checkExpenses(expensesId);
+        checkMember(member, expenses);
+        return ExpensesResponse.from(expenses);
+    }
+
+    @Transactional
+    public void deleteExpenses(Member member, Long expensesId) {
+        Expenses expenses = checkExpenses(expensesId);
+        checkMember(member, expenses);
+        expensesRepository.deleteById(expenses.getId());
+    }
+
+    public Category checkCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CustomException(CATEGORY_NOT_EXISTS));
+    }
+
+    public Expenses checkExpenses(Long expensesId) {
+        return expensesRepository.findById(expensesId)
+                .orElseThrow(() -> new CustomException(EXPENSES_NOT_EXISTS));
+    }
+
+    public void checkMember(Member member, Expenses expenses) {
+        if (!Objects.equals(expenses.getMember().getId(), member.getId())) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_SAME);
+        }
+    }
+
 }


### PR DESCRIPTION
## 📃 설명

- resolves #11

## 🔨 작업 내용

1. 지출에 관련된 API가 추가됨에 따라 각각 멤버 엔티티, 카테고리 엔티티와 연관관계 설정
2. 생성, 수정, 삭제, 상세조회 API 추가
   - 생성 시, `카테고리id` 로 해당 카테고리 존재 여부 확인
   - 수정 시, `지출id` 로 해당 지출 내역 존재 여부 확인, 해당 작성자인지 확인, `PATCH` 로 부분 수정 
   - 상세 조회 및 삭제 시, `지출id` 로 해당 지출 내역 존재 여부 확인, 해당 작성자인지 확인

## 💬 기타 사항

- 