### PR TITLE
feat #10: 예산 추천 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,3 +61,12 @@ configurations {
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
 	}
 }
+
+// QueryDSL 설정
+def querydslSrcDir = 'src/main/generated'
+clean {
+	delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}

--- a/src/main/generated/com/wanted/spendtracker/domain/QBaseTimeEntity.java
+++ b/src/main/generated/com/wanted/spendtracker/domain/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.wanted.spendtracker.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = 1872502249L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/spendtracker/domain/QBudget.java
+++ b/src/main/generated/com/wanted/spendtracker/domain/QBudget.java
@@ -1,0 +1,66 @@
+package com.wanted.spendtracker.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBudget is a Querydsl query type for Budget
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBudget extends EntityPathBase<Budget> {
+
+    private static final long serialVersionUID = 1478299245L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBudget budget = new QBudget("budget");
+
+    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+
+    public final NumberPath<Long> amount = createNumber("amount", Long.class);
+
+    public final QCategory category;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    public final NumberPath<Integer> month = createNumber("month", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QBudget(String variable) {
+        this(Budget.class, forVariable(variable), INITS);
+    }
+
+    public QBudget(Path<? extends Budget> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBudget(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBudget(PathMetadata metadata, PathInits inits) {
+        this(Budget.class, metadata, inits);
+    }
+
+    public QBudget(Class<? extends Budget> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.category = inits.isInitialized("category") ? new QCategory(forProperty("category")) : null;
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/wanted/spendtracker/domain/QCategory.java
+++ b/src/main/generated/com/wanted/spendtracker/domain/QCategory.java
@@ -1,0 +1,44 @@
+package com.wanted.spendtracker.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCategory is a Querydsl query type for Category
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCategory extends EntityPathBase<Category> {
+
+    private static final long serialVersionUID = 640283174L;
+
+    public static final QCategory category = new QCategory("category");
+
+    public final ListPath<Budget, QBudget> budgets = this.<Budget, QBudget>createList("budgets", Budget.class, QBudget.class, PathInits.DIRECT2);
+
+    public final ListPath<Expenses, QExpenses> expenses = this.<Expenses, QExpenses>createList("expenses", Expenses.class, QExpenses.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public QCategory(String variable) {
+        super(Category.class, forVariable(variable));
+    }
+
+    public QCategory(Path<? extends Category> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCategory(PathMetadata metadata) {
+        super(Category.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/spendtracker/domain/QExpenses.java
+++ b/src/main/generated/com/wanted/spendtracker/domain/QExpenses.java
@@ -1,0 +1,70 @@
+package com.wanted.spendtracker.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QExpenses is a Querydsl query type for Expenses
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QExpenses extends EntityPathBase<Expenses> {
+
+    private static final long serialVersionUID = -1345619901L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QExpenses expenses = new QExpenses("expenses");
+
+    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+
+    public final NumberPath<Long> amount = createNumber("amount", Long.class);
+
+    public final QCategory category;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final DatePath<java.time.LocalDate> date = createDate("date", java.time.LocalDate.class);
+
+    public final BooleanPath excludeFromTotalAmount = createBoolean("excludeFromTotalAmount");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    public final StringPath memo = createString("memo");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QExpenses(String variable) {
+        this(Expenses.class, forVariable(variable), INITS);
+    }
+
+    public QExpenses(Path<? extends Expenses> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QExpenses(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QExpenses(PathMetadata metadata, PathInits inits) {
+        this(Expenses.class, metadata, inits);
+    }
+
+    public QExpenses(Class<? extends Expenses> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.category = inits.isInitialized("category") ? new QCategory(forProperty("category")) : null;
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/wanted/spendtracker/domain/QMember.java
+++ b/src/main/generated/com/wanted/spendtracker/domain/QMember.java
@@ -1,0 +1,48 @@
+package com.wanted.spendtracker.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1778706882L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final StringPath accountName = createString("accountName");
+
+    public final ListPath<Budget, QBudget> budgets = this.<Budget, QBudget>createList("budgets", Budget.class, QBudget.class, PathInits.DIRECT2);
+
+    public final ListPath<Expenses, QExpenses> expenses = this.<Expenses, QExpenses>createList("expenses", Expenses.class, QExpenses.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/wanted/spendtracker/config/QuerydslConfig.java
+++ b/src/main/java/com/wanted/spendtracker/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.wanted.spendtracker.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/wanted/spendtracker/controller/BudgetController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/BudgetController.java
@@ -1,13 +1,17 @@
 package com.wanted.spendtracker.controller;
 
+import com.wanted.spendtracker.domain.Member;
 import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.BudgetRecommendRequest;
 import com.wanted.spendtracker.dto.request.BudgetSetRequest;
+import com.wanted.spendtracker.dto.response.BudgetRecommendResponse;
 import com.wanted.spendtracker.service.BudgetService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,9 +23,18 @@ public class BudgetController {
     private final BudgetService budgetService;
 
     @PostMapping("/api/budgets")
-    public ResponseEntity<Void> setBudget(@AuthenticationPrincipal MemberAdapter memberAdapter, @Valid @RequestBody BudgetSetRequest budgetSetRequest) {
-        budgetService.setBudget(memberAdapter, budgetSetRequest);
+    public ResponseEntity<Void> setBudget(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                          @Valid @RequestBody BudgetSetRequest budgetSetRequest) {
+        Member member = memberAdapter.getMember();
+        budgetService.setBudget(member, budgetSetRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/api/budgets/recommend")
+    public ResponseEntity<BudgetRecommendResponse> recommendBudget(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                                  @Valid @RequestBody BudgetRecommendRequest budgetRecommendRequest) {
+        BudgetRecommendResponse budgetRecommendResponse = budgetService.recommendBudget(budgetRecommendRequest);
+        return ResponseEntity.ok().body(budgetRecommendResponse);
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/domain/Budget.java
+++ b/src/main/java/com/wanted/spendtracker/domain/Budget.java
@@ -21,12 +21,12 @@ public class Budget extends BaseTimeEntity{
     @Column(nullable = false)
     private Integer month;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne
-    @JoinColumn(name = "catefory_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     @Builder

--- a/src/main/java/com/wanted/spendtracker/dto/request/BudgetRecommendRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/BudgetRecommendRequest.java
@@ -1,0 +1,25 @@
+package com.wanted.spendtracker.dto.request;
+
+import com.wanted.spendtracker.validation.AmountUnit;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BudgetRecommendRequest {
+
+    @NotNull(message = "BUDGET_AMOUNT_EMPTY")
+    @Min(value = 0, message = "BUDGET_AMOUNT_INVALID")
+    @AmountUnit
+    private Long amount;
+
+    @Builder
+    private BudgetRecommendRequest(Long amount) {
+        this.amount = amount;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/BudgetRecommendResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/BudgetRecommendResponse.java
@@ -8,18 +8,18 @@ import java.util.List;
 @Getter
 public class BudgetRecommendResponse {
 
-    private final Long amount;
+    private final Long totalAmount;
     private final List<CategoryAmountResponse> categoryAmountResponses;
 
     @Builder
-    private BudgetRecommendResponse(Long amount, List<CategoryAmountResponse> categoryAmountResponses) {
-        this.amount = amount;
+    private BudgetRecommendResponse(Long totalAmount, List<CategoryAmountResponse> categoryAmountResponses) {
+        this.totalAmount = totalAmount;
         this.categoryAmountResponses = categoryAmountResponses;
     }
 
-    public static BudgetRecommendResponse of(Long amount, List<CategoryAmountResponse> categoryAmountResponses) {
+    public static BudgetRecommendResponse of(Long totalAmount, List<CategoryAmountResponse> categoryAmountResponses) {
         return BudgetRecommendResponse.builder()
-                .amount(amount)
+                .totalAmount(totalAmount)
                 .categoryAmountResponses(categoryAmountResponses).build();
     }
 

--- a/src/main/java/com/wanted/spendtracker/dto/response/BudgetRecommendResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/BudgetRecommendResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class BudgetRecommendResponse {
+
+    private final Long amount;
+    private final List<CategoryAmountResponse> categoryAmountResponses;
+
+    @Builder
+    private BudgetRecommendResponse(Long amount, List<CategoryAmountResponse> categoryAmountResponses) {
+        this.amount = amount;
+        this.categoryAmountResponses = categoryAmountResponses;
+    }
+
+    public static BudgetRecommendResponse of(Long amount, List<CategoryAmountResponse> categoryAmountResponses) {
+        return BudgetRecommendResponse.builder()
+                .amount(amount)
+                .categoryAmountResponses(categoryAmountResponses).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/CategoryAmountResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/CategoryAmountResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CategoryAmountResponse {
+
+    private final Long categoryId;
+    private final Long amount;
+
+    @Builder
+    public CategoryAmountResponse(Long categoryId, Long amount) {
+        this.categoryId = categoryId;
+        this.amount = amount;
+    }
+
+    public CategoryAmountResponse(Long categoryId, double amount) {
+        this.categoryId = categoryId;
+        this.amount = (long) amount;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
 
     CATEGORY_NOT_EXISTS("카테고리가 존재하지 않습니다.", BAD_REQUEST),
 
+    AMOUNT_UNIT_INVALID("금액을 100원 단위로 입력해주세요.", BAD_REQUEST),
+
     BUDGET_MONTH_EMPTY("예산 월이 존재하지 않습니다.", BAD_REQUEST),
     BUDGET_MONTH_INVALID("예산 월이 유효하지 않습니다.", BAD_REQUEST),
     BUDGET_AMOUNT_EMPTY("예산 금액이 설정되지 않았습니다.", BAD_REQUEST),

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
@@ -2,6 +2,10 @@ package com.wanted.spendtracker.repository;
 
 import com.wanted.spendtracker.domain.Budget;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface BudgetRepository extends JpaRepository<Budget, Long> {
+public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRepositoryCustom {
+    @Query("SELECT sum(b.amount) FROM Budget b")
+    Long getTotalBudgetAmount();
+
 }

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.wanted.spendtracker.repository;
+
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
+
+import java.util.List;
+
+public interface BudgetRepositoryCustom {
+    List<CategoryAmountResponse> getCategoriesAverageAmount();
+}

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
@@ -5,5 +5,6 @@ import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
 import java.util.List;
 
 public interface BudgetRepositoryCustom {
-    List<CategoryAmountResponse> getCategoriesAverageAmount();
+    List<CategoryAmountResponse> getTotalCategoryAmount();
+
 }

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
@@ -16,7 +16,7 @@ public class BudgetRepositoryImpl implements BudgetRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<CategoryAmountResponse> getCategoriesAverageAmount() {
+    public List<CategoryAmountResponse> getTotalCategoryAmount() {
         return jpaQueryFactory
                 .select(Projections.constructor(CategoryAmountResponse.class,
                         budget.category.id.as("categoryId"),

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.wanted.spendtracker.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.wanted.spendtracker.domain.QBudget.budget;
+
+
+@RequiredArgsConstructor
+public class BudgetRepositoryImpl implements BudgetRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CategoryAmountResponse> getCategoriesAverageAmount() {
+        return jpaQueryFactory
+                .select(Projections.constructor(CategoryAmountResponse.class,
+                        budget.category.id.as("categoryId"),
+                        budget.amount.avg().as("amount")))
+                .from(budget)
+                .groupBy(budget.category.id)
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
@@ -20,7 +20,7 @@ public class BudgetRepositoryImpl implements BudgetRepositoryCustom{
         return jpaQueryFactory
                 .select(Projections.constructor(CategoryAmountResponse.class,
                         budget.category.id.as("categoryId"),
-                        budget.amount.avg().as("amount")))
+                        budget.amount.sum().as("amount")))
                 .from(budget)
                 .groupBy(budget.category.id)
                 .fetch();

--- a/src/main/java/com/wanted/spendtracker/service/BudgetService.java
+++ b/src/main/java/com/wanted/spendtracker/service/BudgetService.java
@@ -48,28 +48,28 @@ public class BudgetService {
     public BudgetRecommendResponse recommendBudget(BudgetRecommendRequest budgetRecommendRequest) {
         Long amount = budgetRecommendRequest.getAmount();
         Long totalBudgetAmount = budgetRepository.getTotalBudgetAmount();
-        List<CategoryAmountResponse> categoryAmountResponses = budgetRepository.getCategoriesAverageAmount();
-        List<CategoryAmountResponse> recommendedAmount = new ArrayList<>();
-        Long budgetAmount = 0L;
-        for(CategoryAmountResponse response : categoryAmountResponses) {
-            CategoryAmountResponse averageAmount = CategoryAmountResponse.builder()
-                    .categoryId(response.getCategoryId())
-                    .amount(recommend(response, amount, totalBudgetAmount)).build();
-            recommendedAmount.add(averageAmount);
-            budgetAmount += averageAmount.getAmount();
+        List<CategoryAmountResponse> totalCategoryAmounts = budgetRepository.getTotalCategoryAmount();
+        List<CategoryAmountResponse> recommendedCategoryAmounts = new ArrayList<>();
+        Long totalRecommendedBudget = 0L;
+        for(CategoryAmountResponse totalCategoryAmount : totalCategoryAmounts) {
+            CategoryAmountResponse categoryAmount = CategoryAmountResponse.builder()
+                    .categoryId(totalCategoryAmount.getCategoryId())
+                    .amount(recommend(totalCategoryAmount, totalBudgetAmount, amount)).build();
+            recommendedCategoryAmounts.add(categoryAmount);
+            totalRecommendedBudget += categoryAmount.getAmount();
         }
-        return BudgetRecommendResponse.of(budgetAmount, recommendedAmount);
+        return BudgetRecommendResponse.of(totalRecommendedBudget, recommendedCategoryAmounts);
     }
 
     /**
      * 각 카테고리 별 예산 금액을 추천하기 위한 계산 로직
-     * @param response 카데고리 별 총 예산과 카데고리Id 를 담은 dto
+     * @param totalCategoryAmount 카데고리 별 총 예산과 카데고리Id 를 담은 dto
      * @param amount 사용자가 설정한 총 예산 금액
      * @param totalBudgetAmount DB의 총 예산 금액
      * @return 해당 카테고리 추천 예산 금액 (백의 자리에서 반올림)
      */
-    public Long recommend(CategoryAmountResponse response, Long amount, Long totalBudgetAmount) {
-        return round(((response.getAmount() / (double)totalBudgetAmount) * amount) / 1000.0) * 1000;
+    public Long recommend(CategoryAmountResponse totalCategoryAmount, Long totalBudgetAmount, Long amount) {
+        return round(((totalCategoryAmount.getAmount() / (double)totalBudgetAmount) * amount) / 1000.0) * 1000;
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/service/BudgetService.java
+++ b/src/main/java/com/wanted/spendtracker/service/BudgetService.java
@@ -42,7 +42,7 @@ public class BudgetService {
 
     /**
      * 예산 추천 기능
-     * @param budgetRecommendRequest 사용자가 설정한 예산 금액
+     * @param budgetRecommendRequest 사용자가 설정한 예산 금액을 담은 dto
      * @return 카테고리 별 추천 예산 금액과 총 추천 예산 금액
      */
     public BudgetRecommendResponse recommendBudget(BudgetRecommendRequest budgetRecommendRequest) {

--- a/src/main/java/com/wanted/spendtracker/service/BudgetService.java
+++ b/src/main/java/com/wanted/spendtracker/service/BudgetService.java
@@ -3,8 +3,11 @@ package com.wanted.spendtracker.service;
 import com.wanted.spendtracker.domain.Budget;
 import com.wanted.spendtracker.domain.Category;
 import com.wanted.spendtracker.domain.Member;
-import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.request.BudgetRecommendRequest;
 import com.wanted.spendtracker.dto.request.BudgetSetRequest;
+import com.wanted.spendtracker.dto.request.BudgetSetRequest.BudgetRequest;
+import com.wanted.spendtracker.dto.response.BudgetRecommendResponse;
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
 import com.wanted.spendtracker.exception.CustomException;
 import com.wanted.spendtracker.repository.BudgetRepository;
 import com.wanted.spendtracker.repository.CategoryRepository;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.wanted.spendtracker.exception.ErrorCode.CATEGORY_NOT_EXISTS;
@@ -24,16 +28,41 @@ public class BudgetService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public void setBudget(MemberAdapter memberAdapter, BudgetSetRequest budgetSetRequest) {
-        Member member = memberAdapter.getMember();
-        List<BudgetSetRequest.BudgetRequest> budgetRequests = budgetSetRequest.getBudgetRequestList();
-        for (BudgetSetRequest.BudgetRequest budgetRequest : budgetRequests) {
+    public void setBudget(Member member, BudgetSetRequest budgetSetRequest) {
+        List<BudgetRequest> budgetRequests = budgetSetRequest.getBudgetRequestList();
+        for (BudgetRequest budgetRequest : budgetRequests) {
             Category category = categoryRepository.findById(budgetRequest.getCategoryId())
                     .orElseThrow(() -> new CustomException(CATEGORY_NOT_EXISTS));
             Budget budget = Budget.of(budgetRequest.getAmount(), budgetRequest.getMonth(), member, category);
             budgetRepository.save(budget);
         }
 
+    }
+
+    public BudgetRecommendResponse recommendBudget(BudgetRecommendRequest budgetRecommendRequest) {
+        Long budgetAmount = budgetRecommendRequest.getAmount();
+        Long totalAmount = budgetRepository.getTotalBudgetAmount();
+        List<CategoryAmountResponse> categoryAmountResponses = budgetRepository.getCategoriesAverageAmount();
+        List<CategoryAmountResponse> recommendedAmount = new ArrayList<>();
+        for(CategoryAmountResponse response : categoryAmountResponses) {
+            CategoryAmountResponse averageAmount = CategoryAmountResponse.builder()
+                    .categoryId(response.getCategoryId())
+                    .amount(recommend(response, budgetAmount, totalAmount)).build();
+            recommendedAmount.add(averageAmount);
+        }
+        return BudgetRecommendResponse.of(budgetAmount, recommendedAmount);
+    }
+
+    /**
+     * 각 카테고리 별 예산 금액을 추천하기 위한 계산 로직
+     * @param response 카데고리 별 총 예산과 카데고리Id 를 담은 dto
+     * @param budgetAmount 사용자가 설정한 총 예산 금액
+     * @param totalAmount DB의 총 예산 금액
+     * @return 해당 카테고리 추천 예산 금액
+     */
+
+    public Long recommend(CategoryAmountResponse response, Long budgetAmount, Long totalAmount) {
+        return (long) (((double)response.getAmount() / (double)totalAmount) * budgetAmount);
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/validation/AmountUnit.java
+++ b/src/main/java/com/wanted/spendtracker/validation/AmountUnit.java
@@ -1,0 +1,20 @@
+package com.wanted.spendtracker.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AmountUnitValidator.class)
+public @interface AmountUnit {
+
+    String message() default "AMOUNT_UNIT_INVALID";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/wanted/spendtracker/validation/AmountUnitValidator.java
+++ b/src/main/java/com/wanted/spendtracker/validation/AmountUnitValidator.java
@@ -1,0 +1,15 @@
+package com.wanted.spendtracker.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AmountUnitValidator implements ConstraintValidator<AmountUnit, Long> {
+
+    public static final int MONEY_UNIT = 100;
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        return value != null && value % MONEY_UNIT == 0;
+    }
+
+}


### PR DESCRIPTION
## 📃 설명

- resolves #10 

## 🔨 작업 내용

1. QueryDsl 설정
2. 사용자가 예산 금액 입력 시 기존 유저들의 카테고리 별 예산 평균 값에 따라 카테고리 별 예산 추천 금액 계산하여 응답
3. 예산 금액 입력 시 100원 단위로 받기 위해 Custom Validator 설정

## 💬 기타 사항
- postman 요청 결과 화면
<img width="500" alt="스크린샷 2023-11-26 오후 9 14 20" src="https://github.com/Wanted-Pre-Onboarding-Backend7-R/spend-tracker/assets/110372498/78ae8d3b-c904-45c3-8e4f-48341d0cf602">

- 추천 금액 반올림 코드 추가 완료

</br>



