### PR TITLE
feat #12: 지출 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
@@ -4,7 +4,7 @@ import com.wanted.spendtracker.domain.Member;
 import com.wanted.spendtracker.domain.MemberAdapter;
 import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
 import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
-import com.wanted.spendtracker.dto.response.ExpensesResponse;
+import com.wanted.spendtracker.dto.response.ExpensesGetResponse;
 import com.wanted.spendtracker.service.ExpensesService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,10 +38,10 @@ public class ExpensesController {
     }
 
     @GetMapping ("/api/expenses/{expensesId}")
-    public ResponseEntity<ExpensesResponse> getExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
-                                                        @PathVariable Long expensesId) {
+    public ResponseEntity<ExpensesGetResponse> getExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                           @PathVariable Long expensesId) {
         Member member = memberAdapter.getMember();
-        ExpensesResponse expensesResponse = expensesService.getExpenses(member, expensesId);
+        ExpensesGetResponse expensesResponse = expensesService.getExpenses(member, expensesId);
         return ResponseEntity.ok().body(expensesResponse);
     }
 

--- a/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/ExpensesController.java
@@ -3,11 +3,15 @@ package com.wanted.spendtracker.controller;
 import com.wanted.spendtracker.domain.Member;
 import com.wanted.spendtracker.domain.MemberAdapter;
 import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
+import com.wanted.spendtracker.dto.request.ExpensesGetListRequest;
 import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
+import com.wanted.spendtracker.dto.response.ExpensesGetListResponse;
 import com.wanted.spendtracker.dto.response.ExpensesGetResponse;
 import com.wanted.spendtracker.service.ExpensesService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,8 +34,8 @@ public class ExpensesController {
 
     @PatchMapping ("/api/expenses/{expensesId}")
     public ResponseEntity<Void> updateExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
-                                                           @PathVariable Long expensesId,
-                                                           @Valid @RequestBody ExpensesUpdateRequest expensesUpdateRequest) {
+                                               @PathVariable Long expensesId,
+                                               @Valid @RequestBody ExpensesUpdateRequest expensesUpdateRequest) {
         Member member = memberAdapter.getMember();
         expensesService.updateExpenses(member, expensesId, expensesUpdateRequest);
         return ResponseEntity.ok().build();
@@ -45,9 +49,18 @@ public class ExpensesController {
         return ResponseEntity.ok().body(expensesResponse);
     }
 
+    @GetMapping ("/api/expenses")
+    public ResponseEntity<ExpensesGetListResponse> getExpensesList(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                                                   @Valid @RequestBody ExpensesGetListRequest expensesGetRequest,
+                                                                   @PageableDefault Pageable pageable) {
+        Member member = memberAdapter.getMember();
+        ExpensesGetListResponse expensesList = expensesService.getExpensesList(member, expensesGetRequest, pageable);
+        return ResponseEntity.ok().body(expensesList);
+    }
+
     @DeleteMapping ("/api/expenses/{expensesId}")
     public ResponseEntity<Void> deleteExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter,
-                                                        @PathVariable Long expensesId) {
+                                               @PathVariable Long expensesId) {
         Member member = memberAdapter.getMember();
         expensesService.deleteExpenses(member, expensesId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/wanted/spendtracker/dto/request/ExpensesCreateRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/ExpensesCreateRequest.java
@@ -1,8 +1,8 @@
 package com.wanted.spendtracker.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +24,7 @@ public class ExpensesCreateRequest {
     private LocalDate date;
 
     @NotNull(message = "EXPENSES_AMOUNT_EMPTY")
-    @Min(value = 0, message = "EXPENSES_AMOUNT_INVALID")
+    @PositiveOrZero(message = "EXPENSES_AMOUNT_INVALID")
     private Long amount;
 
     private String memo;

--- a/src/main/java/com/wanted/spendtracker/dto/request/ExpensesGetListRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/ExpensesGetListRequest.java
@@ -1,0 +1,39 @@
+package com.wanted.spendtracker.dto.request;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpensesGetListRequest {
+
+    private Long categoryId;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @PositiveOrZero(message = "EXPENSES_AMOUNT_INVALID")
+    private Long minAmount;
+
+    @PositiveOrZero(message = "EXPENSES_AMOUNT_INVALID")
+    private Long maxAmount;
+
+    @Builder
+    private ExpensesGetListRequest(Long categoryId, LocalDate startDate, LocalDate endDate, Long minAmount, Long maxAmount) {
+        this.categoryId = categoryId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.minAmount = minAmount;
+        this.maxAmount = maxAmount;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/request/ExpensesUpdateRequest.java
+++ b/src/main/java/com/wanted/spendtracker/dto/request/ExpensesUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.wanted.spendtracker.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +18,7 @@ public class ExpensesUpdateRequest {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate date;
 
-    @Min(value = 0, message = "EXPENSES_AMOUNT_INVALID")
+    @PositiveOrZero(message = "EXPENSES_AMOUNT_INVALID")
     private Long amount;
 
     private String memo;

--- a/src/main/java/com/wanted/spendtracker/dto/response/CategoryAmountResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/CategoryAmountResponse.java
@@ -15,6 +15,12 @@ public class CategoryAmountResponse {
         this.amount = amount;
     }
 
+    public static CategoryAmountResponse of(Long categoryId, Long amount) {
+        return CategoryAmountResponse.builder()
+                .categoryId(categoryId)
+                .amount(amount).build();
+    }
+
     public CategoryAmountResponse(Long categoryId, double amount) {
         this.categoryId = categoryId;
         this.amount = (long) amount;

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetListResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetListResponse.java
@@ -1,0 +1,42 @@
+package com.wanted.spendtracker.dto.response;
+
+import com.wanted.spendtracker.domain.Expenses;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class ExpensesGetListResponse {
+    private final Long totalExpensesAmount;
+    private final List<CategoryAmountResponse> totalCategoryAmountList;
+    private final List<ExpensesGetResponse> expensesList;
+    private final Long totalElements;
+    private final Integer totalPages;
+
+
+    @Builder
+    private ExpensesGetListResponse(List<ExpensesGetResponse> expensesList,
+                                    Long totalExpensesAmount,
+                                    List<CategoryAmountResponse> totalCategoryAmountList, Long totalElements, Integer totalPages) {
+        this.expensesList = expensesList;
+        this.totalExpensesAmount = totalExpensesAmount;
+        this.totalCategoryAmountList = totalCategoryAmountList;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    public static ExpensesGetListResponse of(List<ExpensesGetResponse> expensesList,
+                                             Long totalExpensesAmount,
+                                             List<CategoryAmountResponse> totalCategoryAmountList,
+                                             Page<Expenses> expensesPage) {
+        return ExpensesGetListResponse.builder()
+                .expensesList(expensesList)
+                .totalExpensesAmount(totalExpensesAmount)
+                .totalCategoryAmountList(totalCategoryAmountList)
+                .totalElements(expensesPage.getTotalElements())
+                .totalPages(expensesPage.getTotalPages()).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetResponse.java
@@ -9,8 +9,6 @@ import java.time.LocalDate;
 @Getter
 public class ExpensesGetResponse {
 
-    private final Long memberId;
-
     private final Long categoryId;
 
     private final LocalDate date;
@@ -22,8 +20,7 @@ public class ExpensesGetResponse {
     private final Boolean excludeFromTotalAmount;
 
     @Builder
-    private ExpensesGetResponse(Long memberId, Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
-        this.memberId = memberId;
+    private ExpensesGetResponse(Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
         this.categoryId = categoryId;
         this.date = date;
         this.amount = amount;
@@ -33,7 +30,6 @@ public class ExpensesGetResponse {
 
     public static ExpensesGetResponse from(Expenses expenses) {
         return ExpensesGetResponse.builder()
-                .memberId(expenses.getMember().getId())
                 .categoryId(expenses.getCategory().getId())
                 .date(expenses.getDate())
                 .amount(expenses.getAmount())

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesGetResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 
 @Getter
-public class ExpensesResponse {
+public class ExpensesGetResponse {
 
     private final Long memberId;
 
@@ -22,7 +22,7 @@ public class ExpensesResponse {
     private final Boolean excludeFromTotalAmount;
 
     @Builder
-    private ExpensesResponse(Long memberId, Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
+    private ExpensesGetResponse(Long memberId, Long categoryId, LocalDate date, Long amount, String memo, Boolean excludeFromTotalAmount) {
         this.memberId = memberId;
         this.categoryId = categoryId;
         this.date = date;
@@ -31,8 +31,8 @@ public class ExpensesResponse {
         this.excludeFromTotalAmount = excludeFromTotalAmount;
     }
 
-    public static ExpensesResponse from(Expenses expenses) {
-        return ExpensesResponse.builder()
+    public static ExpensesGetResponse from(Expenses expenses) {
+        return ExpensesGetResponse.builder()
                 .memberId(expenses.getMember().getId())
                 .categoryId(expenses.getCategory().getId())
                 .date(expenses.getDate())

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepository.java
@@ -3,5 +3,5 @@ package com.wanted.spendtracker.repository;
 import com.wanted.spendtracker.domain.Expenses;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExpensesRepository extends JpaRepository<Expenses, Long> {
+public interface ExpensesRepository extends JpaRepository<Expenses, Long>, ExpensesRepositoryCustom {
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.wanted.spendtracker.repository;
+
+import com.wanted.spendtracker.domain.Expenses;
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.request.ExpensesGetListRequest;
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ExpensesRepositoryCustom {
+    Page<Expenses> findAllByExpensesGetRequest(Member member, ExpensesGetListRequest expensesGetRequest, Pageable pageable);
+    List<CategoryAmountResponse> findTotalCategoryAmount(Member member, ExpensesGetListRequest expensesGetRequest);
+
+}

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.wanted.spendtracker.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.spendtracker.domain.Expenses;
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.request.ExpensesGetListRequest;
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.wanted.spendtracker.domain.QExpenses.expenses;
+
+@RequiredArgsConstructor
+public class ExpensesRepositoryImpl implements ExpensesRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Expenses> findAllByExpensesGetRequest(Member member, ExpensesGetListRequest expensesGetRequest, Pageable pageable) {
+        List<Expenses> expensesList = jpaQueryFactory
+                .selectFrom(expenses)
+                .where(
+                        memberEq(member.getId()),
+                        categoryEq(expensesGetRequest.getCategoryId()),
+                        startDateAfter(expensesGetRequest.getStartDate()),
+                        endDateBefore(expensesGetRequest.getEndDate()),
+                        minAmountGoe(expensesGetRequest.getMinAmount()),
+                        maxAmountLoe(expensesGetRequest.getMaxAmount())
+                )
+                .orderBy(expenses.date.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(expenses.count())
+                .from(expenses)
+                .where(
+                        memberEq(member.getId()),
+                        categoryEq(expensesGetRequest.getCategoryId()),
+                        startDateAfter(expensesGetRequest.getStartDate()),
+                        endDateBefore(expensesGetRequest.getEndDate()),
+                        minAmountGoe(expensesGetRequest.getMinAmount()),
+                        maxAmountLoe(expensesGetRequest.getMaxAmount())
+                );
+
+        return PageableExecutionUtils.getPage(expensesList, pageable, countQuery::fetchOne);
+
+    }
+
+    @Override
+    public List<CategoryAmountResponse> findTotalCategoryAmount(Member member, ExpensesGetListRequest expensesGetRequest) {
+        return jpaQueryFactory
+                .select(Projections.constructor(CategoryAmountResponse.class,
+                        expenses.category.id.as("category_id"),
+                        expenses.amount.sum().as(("amount")))
+                )
+                .from(expenses)
+                .where(
+                        memberEq(member.getId()),
+                        categoryEq(expensesGetRequest.getCategoryId()),
+                        startDateAfter(expensesGetRequest.getStartDate()),
+                        endDateBefore(expensesGetRequest.getEndDate()),
+                        minAmountGoe(expensesGetRequest.getMinAmount()),
+                        maxAmountLoe(expensesGetRequest.getMaxAmount()),
+                        isExcluded(expenses.excludeFromTotalAmount)
+                )
+                .groupBy(expenses.category.id)
+                .fetch();
+    }
+
+    private BooleanExpression isExcluded(BooleanPath excludeFromTotalAmount) {
+        return excludeFromTotalAmount != null ? excludeFromTotalAmount.eq(false) : null;
+    }
+
+    private BooleanExpression maxAmountLoe(Long maxAmount) {
+        return maxAmount != null ? expenses.amount.loe(maxAmount) : null;
+    }
+
+    private BooleanExpression minAmountGoe(Long minAmount) {
+        return minAmount != null ? expenses.amount.goe(minAmount) : null;
+    }
+
+    private BooleanExpression endDateBefore(LocalDate endDate) {
+        return endDate != null ? expenses.date.loe(endDate) : null;
+    }
+
+    private BooleanExpression startDateAfter(LocalDate startDate) {
+        return startDate != null ? expenses.date.goe(startDate) : null;
+    }
+
+    private BooleanExpression categoryEq(Long categoryId) {
+        return categoryId != null ? expenses.category.id.eq(categoryId) : null;
+    }
+
+    private BooleanExpression memberEq(Long memberId) {
+        return memberId != null ? expenses.member.id.eq(memberId) : null;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
@@ -54,10 +54,11 @@ public class ExpensesService {
         return ExpensesGetResponse.from(expenses);
     }
 
+    @Transactional(readOnly = true)
     public ExpensesGetListResponse getExpensesList(Member member, ExpensesGetListRequest expensesGetRequest, Pageable pageable) {
         Page<Expenses> expenses  = expensesRepository.findAllByExpensesGetRequest(member, expensesGetRequest, pageable);
         List<Expenses> expensesList = expenses.getContent();
-        List<ExpensesGetResponse> expensesGetResponseList = expensesToResponseList(expensesList);
+        List<ExpensesGetResponse> expensesGetResponseList = expensesListToResponseList(expensesList);
         Long totalExpensesAmount = getTotalExpensesAmount(expensesList);
         List<CategoryAmountResponse> totalCategoryAmountList = expensesRepository.findTotalCategoryAmount(member, expensesGetRequest);
         return ExpensesGetListResponse.of(expensesGetResponseList, totalExpensesAmount, totalCategoryAmountList, expenses);
@@ -77,7 +78,7 @@ public class ExpensesService {
                 .sum();
     }
 
-    private List<ExpensesGetResponse> expensesToResponseList(List<Expenses> expensesList) {
+    private List<ExpensesGetResponse> expensesListToResponseList(List<Expenses> expensesList) {
         return expensesList.stream()
                 .map(ExpensesGetResponse::from)
                 .toList();

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
@@ -5,7 +5,7 @@ import com.wanted.spendtracker.domain.Expenses;
 import com.wanted.spendtracker.domain.Member;
 import com.wanted.spendtracker.dto.request.ExpensesCreateRequest;
 import com.wanted.spendtracker.dto.request.ExpensesUpdateRequest;
-import com.wanted.spendtracker.dto.response.ExpensesResponse;
+import com.wanted.spendtracker.dto.response.ExpensesGetResponse;
 import com.wanted.spendtracker.exception.CustomException;
 import com.wanted.spendtracker.exception.ErrorCode;
 import com.wanted.spendtracker.repository.CategoryRepository;
@@ -42,10 +42,10 @@ public class ExpensesService {
     }
 
     @Transactional(readOnly = true)
-    public ExpensesResponse getExpenses(Member member, Long expensesId) {
+    public ExpensesGetResponse getExpenses(Member member, Long expensesId) {
         Expenses expenses = checkExpenses(expensesId);
         checkMember(member, expenses);
-        return ExpensesResponse.from(expenses);
+        return ExpensesGetResponse.from(expenses);
     }
 
     @Transactional


### PR DESCRIPTION
## 📃 설명

- resolves #12
- 조회 시 필터링 조건
    - `지출 기간` 으로 조회
    - `지출 카테고리` 로 조회
    - `지출 최소 금액` ,`지출 최대 금액` 으로 조회
    - 조회된 모든 지출 내역 `총 지출 합계`, `카테고리 별 지출 합계` 같이 반환
    - `합계 제외` 처리한 지출은 목록에 포함되지만, `총 지출 합계`, `카테고리 별 지출 합계`에서 제외
    - 지출 시간으로 `내림차순` 하여 반환 (최신순)
- 페이징 처리하여 `총 조회 내역 건수` 와 `총 페이지 수` 함께 반환


## 🔨 작업 내용

- 필터링 조건으로 조회하기 위해 QueryDsl 로 동적쿼리 작성


## 💬 기타 사항
- 요청 성공 예 
<img width="700" alt="스크린샷 2023-11-29 오후 3 01 42" src="https://github.com/Wanted-Pre-Onboarding-Backend7-R/spend-tracker/assets/110372498/d663b4b3-cb89-475c-918b-d0513f633202">
<img width="700" alt="스크린샷 2023-11-29 오후 3 02 07" src="https://github.com/Wanted-Pre-Onboarding-Backend7-R/spend-tracker/assets/110372498/a91b34d4-b150-4946-b145-b8b86dd4524c">


