### PR TITLE
feat #14: 오늘 지출 추천 API 구현

### DIFF
--- a/src/main/java/com/wanted/spendtracker/controller/ExpensesConsultController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/ExpensesConsultController.java
@@ -1,0 +1,26 @@
+package com.wanted.spendtracker.controller;
+
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.response.ExpensesRecommendResponse;
+import com.wanted.spendtracker.service.ExpensesConsultService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ExpensesConsultController {
+
+    private final ExpensesConsultService expensesConsultService;
+
+    @GetMapping("/api/expenses/recommend")
+    public ResponseEntity<ExpensesRecommendResponse> recommendExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter) {
+        Member member = memberAdapter.getMember();
+        ExpensesRecommendResponse expensesRecommendResponse = expensesConsultService.recommendExpenses(member);
+        return ResponseEntity.ok().body(expensesRecommendResponse);
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRecommendResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRecommendResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ExpensesRecommendResponse {
+
+    private final Long totalAvailableExpenses;
+    private final List<CategoryAmountResponse> AvailableExpensesByCategory;
+
+    @Builder
+    private ExpensesRecommendResponse(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategory) {
+        this.totalAvailableExpenses = totalAvailableExpenses;
+        AvailableExpensesByCategory = availableExpensesByCategory;
+    }
+
+    public static ExpensesRecommendResponse of(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategory) {
+        return ExpensesRecommendResponse.builder()
+                .totalAvailableExpenses(totalAvailableExpenses)
+                .availableExpensesByCategory(availableExpensesByCategory).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
@@ -8,4 +8,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRep
     @Query("SELECT sum(b.amount) FROM Budget b")
     Long getTotalBudgetAmount();
 
+    @Query("SELECT sum(b.amount) FROM Budget b where b.member.id = :memberId and b.month = :month")
+    Long getTotalBudgetAmountByMonth(Long memberId, Integer month);
+
 }

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryCustom.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface BudgetRepositoryCustom {
     List<CategoryAmountResponse> getTotalCategoryAmount();
+    List<CategoryAmountResponse> getTotalCategoryAmountByMonth(Long memberId, Integer month);
 
 }

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
@@ -36,13 +36,13 @@ public class BudgetRepositoryImpl implements BudgetRepositoryCustom {
                 .from(budget)
                 .where(
                         memberIdEq(memberId),
-                        monthEd(month)
+                        monthEq(month)
                 )
                 .groupBy(budget.category.id)
                 .fetch();
     }
 
-    private BooleanExpression monthEd(Integer month) {
+    private BooleanExpression monthEq(Integer month) {
         return month != null ? budget.month.eq(month) : null;
     }
 

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.wanted.spendtracker.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,29 @@ public class BudgetRepositoryImpl implements BudgetRepositoryCustom {
                 .from(budget)
                 .groupBy(budget.category.id)
                 .fetch();
+    }
+
+    @Override
+    public List<CategoryAmountResponse> getTotalCategoryAmountByMonth(Long memberId, Integer month) {
+        return jpaQueryFactory
+                .select(Projections.constructor(CategoryAmountResponse.class,
+                        budget.category.id.as("categoryId"),
+                        budget.amount.sum().as("amount")))
+                .from(budget)
+                .where(
+                        memberIdEq(memberId),
+                        monthEd(month)
+                )
+                .groupBy(budget.category.id)
+                .fetch();
+    }
+
+    private BooleanExpression monthEd(Integer month) {
+        return month != null ? budget.month.eq(month) : null;
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return memberId != null ? budget.member.id.eq((memberId)) : null;
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
@@ -7,10 +7,12 @@ import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ExpensesRepositoryCustom {
     Page<Expenses> findAllByExpensesGetRequest(Member member, ExpensesGetListRequest expensesGetRequest, Pageable pageable);
-    List<CategoryAmountResponse> findTotalCategoryAmount(Member member, ExpensesGetListRequest expensesGetRequest);
+    List<CategoryAmountResponse> findTotalCategoryAmountByRequest(Member member, ExpensesGetListRequest expensesGetRequest);
+    Long getTotalExpensesAmountUntilToday(Member member, LocalDate currentDate);
 
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
@@ -57,7 +57,7 @@ public class ExpensesRepositoryImpl implements ExpensesRepositoryCustom {
     }
 
     @Override
-    public List<CategoryAmountResponse> findTotalCategoryAmount(Member member, ExpensesGetListRequest expensesGetRequest) {
+    public List<CategoryAmountResponse> findTotalCategoryAmountByRequest(Member member, ExpensesGetListRequest expensesGetRequest) {
         return jpaQueryFactory
                 .select(Projections.constructor(CategoryAmountResponse.class,
                         expenses.category.id.as("category_id"),
@@ -75,6 +75,21 @@ public class ExpensesRepositoryImpl implements ExpensesRepositoryCustom {
                 )
                 .groupBy(expenses.category.id)
                 .fetch();
+    }
+
+    @Override
+    public Long getTotalExpensesAmountUntilToday(Member member, LocalDate currentDate) {
+        LocalDate firstDayOfMonth = currentDate.withDayOfMonth(1);
+        return jpaQueryFactory
+                .select(expenses.amount.sum())
+                .from(expenses)
+                .where(
+                        memberEq(member.getId()),
+                        startDateAfter(firstDayOfMonth),
+                        endDateBefore(currentDate),
+                        isExcluded(expenses.excludeFromTotalAmount)
+                )
+                .fetchOne();
     }
 
     private BooleanExpression isExcluded(BooleanPath excludeFromTotalAmount) {

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesConsultService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesConsultService.java
@@ -1,0 +1,112 @@
+package com.wanted.spendtracker.service;
+
+import com.wanted.spendtracker.domain.Member;
+import com.wanted.spendtracker.dto.response.CategoryAmountResponse;
+import com.wanted.spendtracker.dto.response.ExpensesRecommendResponse;
+import com.wanted.spendtracker.repository.BudgetRepository;
+import com.wanted.spendtracker.repository.ExpensesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Math.round;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExpensesConsultService {
+
+    private final ExpensesRepository expensesRepository;
+    private final BudgetRepository budgetRepository;
+    private final Long MIN_EXPENSES_AMOUNT = 10000L;
+
+    /**
+     * 오늘의 지출 추천
+     * @param member
+     * @return 추천 지출 총액과 카테고리 별 추천 지출 금액
+     */
+    public ExpensesRecommendResponse recommendExpenses(Member member) {
+        LocalDate currentDate = LocalDate.now();
+        long daysLeftOfThisMonth = calculateDaysLeft(currentDate);
+
+        Long totalBudgetOfThisMonth = getTotalBudgetOfThisMonth(member, currentDate);
+        Long totalExpensesUntilToday = getExpensesUntilToday(member, currentDate);
+        Long totalAvailableExpenses = calculateTotalAvailableExpenses(totalBudgetOfThisMonth, totalExpensesUntilToday, daysLeftOfThisMonth);
+
+        List<CategoryAmountResponse> totalCategoryBudgetOfThisMonth = getTotalCategoryBudgetOfThisMonth(member, currentDate);
+        List<CategoryAmountResponse> availableExpensesByCategory = getAvailableExpensesByCategory(totalCategoryBudgetOfThisMonth, totalBudgetOfThisMonth, totalAvailableExpenses);
+
+        return ExpensesRecommendResponse.of(totalAvailableExpenses, availableExpensesByCategory);
+    }
+
+    private long calculateDaysLeft(LocalDate currentDate) {
+        LocalDate lastDayOfMonth = currentDate.withDayOfMonth(currentDate.lengthOfMonth());
+        return  ChronoUnit.DAYS.between(currentDate, lastDayOfMonth) + 1;
+    }
+
+    private Long getTotalBudgetOfThisMonth (Member member, LocalDate currentDate) {
+        return budgetRepository.getTotalBudgetAmountByMonth(member.getId(), currentDate.getMonthValue());
+    }
+
+    private Long getExpensesUntilToday (Member member, LocalDate currentDate) {
+        return expensesRepository.getTotalExpensesAmountUntilToday(member, currentDate);
+    }
+
+    private List<CategoryAmountResponse> getTotalCategoryBudgetOfThisMonth(Member member, LocalDate currentDate) {
+        return budgetRepository.getTotalCategoryAmountByMonth(member.getId(), currentDate.getMonthValue());
+    }
+
+    /**
+     * 카테고리 별 추천 지출 금액을 반환하는 메소드
+     * @param totalCategoryBudgetOfThisMonth 카데고리 별 총 예산 금액을 담은 리스트
+     * @param totalBudgetOfThisMonth 이번 달 총 예산 금액
+     * @param totalAvailableExpenses 이번 달 사용 가능한 지출 금액
+     * @return 카테고리 별 추천 지출 금액
+     */
+    private List<CategoryAmountResponse> getAvailableExpensesByCategory(List<CategoryAmountResponse> totalCategoryBudgetOfThisMonth,
+                                                                        Long totalBudgetOfThisMonth,
+                                                                        Long totalAvailableExpenses) {
+        List<CategoryAmountResponse> availableExpensesByCategory = new ArrayList<>();
+        for(CategoryAmountResponse CategoryBudgetOfThisMonth : totalCategoryBudgetOfThisMonth) {
+            CategoryAmountResponse categoryAmount = CategoryAmountResponse.builder()
+                    .categoryId(CategoryBudgetOfThisMonth.getCategoryId())
+                    .amount(calculateCategoryAmount(CategoryBudgetOfThisMonth.getAmount(), totalBudgetOfThisMonth, totalAvailableExpenses)).build();
+            availableExpensesByCategory.add(categoryAmount);
+        }
+        return availableExpensesByCategory;
+    }
+
+    /**
+     * 추천 지출 총액을 계산하는 메소드
+     * @param totalBudgetOfThisMonth 이번 달 총 예산 금액
+     * @param totalExpensesUntilToday 이번 달 총 지출 금액 (오늘 기준)
+     * @param daysLeftOfThisMonth 이번 달 남은 날짜의 수
+     * @return 추천 지출 총액 반환 (백의 자리 반올림)
+     */
+    private Long calculateTotalAvailableExpenses(Long totalBudgetOfThisMonth, Long totalExpensesUntilToday, long daysLeftOfThisMonth) {
+        long totalBudgetLeft = totalBudgetOfThisMonth - totalExpensesUntilToday;
+
+        // 남아 있는 예산 금액이 0보다 작거나 같으면 최소 금액 반환
+        if(totalBudgetLeft <= 0) {
+            return MIN_EXPENSES_AMOUNT;
+        }
+        return round((totalBudgetLeft / (double) daysLeftOfThisMonth) / 1000.0) * 1000;
+    }
+
+    /**
+     * 각 카테고리 별 추천 금액을 계산하는 메소드
+     * @param totalCategoryBudgetOfThisMonth 카테고리 별 예산 총액
+     * @param totalBudgetOfThisMonth 이번 달 총 예산 금액
+     * @param totalAvailableExpenses 오늘 지출 가능한 총액
+     * @return 각 카테고리 별 추천 금액 (백의 자리 반올림)
+     */
+    private Long calculateCategoryAmount(Long totalCategoryBudgetOfThisMonth, Long totalBudgetOfThisMonth, Long totalAvailableExpenses) {
+        return round(((totalCategoryBudgetOfThisMonth / (double)totalBudgetOfThisMonth) * totalAvailableExpenses) / 1000.0) * 1000;
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesConsultService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesConsultService.java
@@ -103,10 +103,10 @@ public class ExpensesConsultService {
      * @param totalCategoryBudgetOfThisMonth 카테고리 별 예산 총액
      * @param totalBudgetOfThisMonth 이번 달 총 예산 금액
      * @param totalAvailableExpenses 오늘 지출 가능한 총액
-     * @return 각 카테고리 별 추천 금액 (백의 자리 반올림)
+     * @return 각 카테고리 별 추천 금액 (십의 자리 반올림)
      */
     private Long calculateCategoryAmount(Long totalCategoryBudgetOfThisMonth, Long totalBudgetOfThisMonth, Long totalAvailableExpenses) {
-        return round(((totalCategoryBudgetOfThisMonth / (double)totalBudgetOfThisMonth) * totalAvailableExpenses) / 1000.0) * 1000;
+        return round(((totalCategoryBudgetOfThisMonth / (double)totalBudgetOfThisMonth) * totalAvailableExpenses) / 100.0) * 100;
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
+++ b/src/main/java/com/wanted/spendtracker/service/ExpensesService.java
@@ -60,7 +60,7 @@ public class ExpensesService {
         List<Expenses> expensesList = expenses.getContent();
         List<ExpensesGetResponse> expensesGetResponseList = expensesListToResponseList(expensesList);
         Long totalExpensesAmount = getTotalExpensesAmount(expensesList);
-        List<CategoryAmountResponse> totalCategoryAmountList = expensesRepository.findTotalCategoryAmount(member, expensesGetRequest);
+        List<CategoryAmountResponse> totalCategoryAmountList = expensesRepository.findTotalCategoryAmountByRequest(member, expensesGetRequest);
         return ExpensesGetListResponse.of(expensesGetResponseList, totalExpensesAmount, totalCategoryAmountList, expenses);
     }
 


### PR DESCRIPTION
## 📃 설명

- resolves #14 
    -  오늘 지출 가능한 금액을 `총액` 과 `카테고리 별 금액` 으로 추천
        - 추천 지출 총액 : `이번 달 총 예산 금액`에서 `오늘까지의 지출 금액`을 뺀 금액을 `이번 달 남은 날짜의 수`로 나누어 반환
        - 카테고리 별 추천 지출 금액 : 
            - `이번 달 총 예산 금액`에 따른 `카테고리 별 예산 금액`의 비율을 기준으로 계산하여 반환
            - 십의 자리에서 반올림 
        - `추천 지출 총액`이 `0`보다 작거나(음수), 같으면 `최소 추천 금액`을 반환, `카테고리 별 추천 지출 금액`도 `최소 추천 금액`을 기준으로 계산하여 반환

## 🔨 작업 내용

- QueryDsl 사용하여 동적 쿼리 작성

## 💬 기타 사항
- 요청 성공 예시
<img width="700" alt="스크린샷 2023-11-29 오후 11 12 30" src="https://github.com/Wanted-Pre-Onboarding-Backend7-R/spend-tracker/assets/110372498/c1c64e23-4790-402d-8dcb-f74d4bc0baa2">

