### PR TITLE
feat #15: 오늘 지출 안내 API 구현

### DIFF
--- a/src/main/java/com/wanted/spendtracker/controller/ExpensesConsultController.java
+++ b/src/main/java/com/wanted/spendtracker/controller/ExpensesConsultController.java
@@ -2,6 +2,7 @@ package com.wanted.spendtracker.controller;
 
 import com.wanted.spendtracker.domain.Member;
 import com.wanted.spendtracker.domain.MemberAdapter;
+import com.wanted.spendtracker.dto.response.ExpensesNotificationResponse;
 import com.wanted.spendtracker.dto.response.ExpensesRecommendResponse;
 import com.wanted.spendtracker.service.ExpensesConsultService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,13 @@ public class ExpensesConsultController {
         Member member = memberAdapter.getMember();
         ExpensesRecommendResponse expensesRecommendResponse = expensesConsultService.recommendExpenses(member);
         return ResponseEntity.ok().body(expensesRecommendResponse);
+    }
+
+    @GetMapping("/api/expenses/notify")
+    public ResponseEntity<ExpensesNotificationResponse> notifyExpenses(@AuthenticationPrincipal MemberAdapter memberAdapter) {
+        Member member = memberAdapter.getMember();
+        ExpensesNotificationResponse expensesNotificationResponse = expensesConsultService.notifyExpenses(member);
+        return ResponseEntity.ok().body(expensesNotificationResponse);
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesNotificationResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesNotificationResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ExpensesNotificationResponse {
+    private final Long todayTotalExpenses;
+    private final List<CategoryAmountResponse> todayTotalCategoryExpensesList;
+    private final ExpensesRatioResponse expensesRatioResponse;
+
+    @Builder
+    private ExpensesNotificationResponse(Long todayTotalExpenses,
+                                        List<CategoryAmountResponse> todayTotalCategoryExpensesList,
+                                        ExpensesRatioResponse expensesRatioResponse) {
+        this.todayTotalExpenses = todayTotalExpenses;
+        this.todayTotalCategoryExpensesList = todayTotalCategoryExpensesList;
+        this.expensesRatioResponse = expensesRatioResponse;
+    }
+
+    public static ExpensesNotificationResponse of(Long todayTotalExpenses,
+                                                  List<CategoryAmountResponse> todayTotalCategoryExpensesList,
+                                                  ExpensesRatioResponse expensesRatioResponse) {
+        return ExpensesNotificationResponse.builder()
+                .todayTotalExpenses(todayTotalExpenses)
+                .todayTotalCategoryExpensesList(todayTotalCategoryExpensesList)
+                .expensesRatioResponse(expensesRatioResponse).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRatioResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRatioResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.spendtracker.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExpensesRatioResponse {
+    private final Long availableExpenses;
+    private final Long todayExpenses;
+    private final Double ratioOfExpenses;
+
+    @Builder
+    private ExpensesRatioResponse(Long availableExpenses, Long todayExpenses, Double ratioOfExpenses) {
+        this.availableExpenses = availableExpenses;
+        this.todayExpenses = todayExpenses;
+        this.ratioOfExpenses = ratioOfExpenses;
+    }
+
+    public static ExpensesRatioResponse of(Long availableExpenses, Long todayExpenses, Double ratioOfExpenses) {
+        return ExpensesRatioResponse.builder()
+                .availableExpenses(availableExpenses)
+                .todayExpenses(todayExpenses)
+                .ratioOfExpenses(ratioOfExpenses).build();
+    }
+
+}

--- a/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRecommendResponse.java
+++ b/src/main/java/com/wanted/spendtracker/dto/response/ExpensesRecommendResponse.java
@@ -9,18 +9,18 @@ import java.util.List;
 public class ExpensesRecommendResponse {
 
     private final Long totalAvailableExpenses;
-    private final List<CategoryAmountResponse> AvailableExpensesByCategory;
+    private final List<CategoryAmountResponse> availableExpensesByCategoryList;
 
     @Builder
-    private ExpensesRecommendResponse(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategory) {
+    private ExpensesRecommendResponse(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategoryList) {
         this.totalAvailableExpenses = totalAvailableExpenses;
-        AvailableExpensesByCategory = availableExpensesByCategory;
+        this.availableExpensesByCategoryList = availableExpensesByCategoryList;
     }
 
-    public static ExpensesRecommendResponse of(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategory) {
+    public static ExpensesRecommendResponse of(Long totalAvailableExpenses, List<CategoryAmountResponse> availableExpensesByCategoryList) {
         return ExpensesRecommendResponse.builder()
                 .totalAvailableExpenses(totalAvailableExpenses)
-                .availableExpensesByCategory(availableExpensesByCategory).build();
+                .availableExpensesByCategoryList(availableExpensesByCategoryList).build();
     }
 
 }

--- a/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/spendtracker/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     BUDGET_AMOUNT_EMPTY("예산 금액이 설정되지 않았습니다.", BAD_REQUEST),
     BUDGET_AMOUNT_INVALID("예산 금액이 유효하지 않습니다.", BAD_REQUEST),
     BUDGET_REQUEST_EMPTY("예산 금액 요청이 존재하지 않습니다.", BAD_REQUEST),
+    BUDGET_NOT_EXISTS("예산을 먼저 설정해주세요.", BAD_REQUEST),
 
     EXPENSES_DATE_EMPTY("지출 날짜가 존재하지 않습니다.", BAD_REQUEST),
     EXPENSES_EXCLUDE_FROM_TOTAL_AMOUNT_EMPTY("지출 함계 여부가 설정되지 않았습니다", BAD_REQUEST),

--- a/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/BudgetRepository.java
@@ -4,11 +4,13 @@ import com.wanted.spendtracker.domain.Budget;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRepositoryCustom {
     @Query("SELECT sum(b.amount) FROM Budget b")
     Long getTotalBudgetAmount();
 
     @Query("SELECT sum(b.amount) FROM Budget b where b.member.id = :memberId and b.month = :month")
-    Long getTotalBudgetAmountByMonth(Long memberId, Integer month);
+    Optional<Long> getTotalBudgetAmountByMonth(Long memberId, Integer month);
 
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepository.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepository.java
@@ -2,6 +2,13 @@ package com.wanted.spendtracker.repository;
 
 import com.wanted.spendtracker.domain.Expenses;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
 
 public interface ExpensesRepository extends JpaRepository<Expenses, Long>, ExpensesRepositoryCustom {
+
+    @Query("SELECT sum(e.amount) FROM Expenses e where e.member.id = :memberId and e.date = :currentDate")
+    Long getTodayTotalExpenses(Long memberId, LocalDate currentDate);
+
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryCustom.java
@@ -14,5 +14,6 @@ public interface ExpensesRepositoryCustom {
     Page<Expenses> findAllByExpensesGetRequest(Member member, ExpensesGetListRequest expensesGetRequest, Pageable pageable);
     List<CategoryAmountResponse> findTotalCategoryAmountByRequest(Member member, ExpensesGetListRequest expensesGetRequest);
     Long getTotalExpensesAmountUntilToday(Member member, LocalDate currentDate);
+    List<CategoryAmountResponse> getTodayTotalCategoryExpenses(Member member, LocalDate currentDate);
 
 }

--- a/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
+++ b/src/main/java/com/wanted/spendtracker/repository/ExpensesRepositoryImpl.java
@@ -61,7 +61,7 @@ public class ExpensesRepositoryImpl implements ExpensesRepositoryCustom {
         return jpaQueryFactory
                 .select(Projections.constructor(CategoryAmountResponse.class,
                         expenses.category.id.as("category_id"),
-                        expenses.amount.sum().as(("amount")))
+                        expenses.amount.sum().as("amount"))
                 )
                 .from(expenses)
                 .where(
@@ -90,6 +90,26 @@ public class ExpensesRepositoryImpl implements ExpensesRepositoryCustom {
                         isExcluded(expenses.excludeFromTotalAmount)
                 )
                 .fetchOne();
+    }
+
+    @Override
+    public List<CategoryAmountResponse> getTodayTotalCategoryExpenses(Member member, LocalDate currentDate) {
+        return jpaQueryFactory
+                .select(Projections.constructor(CategoryAmountResponse.class,
+                        expenses.category.id.as("category_id"),
+                        expenses.amount.sum().as("amount"))
+                )
+                .from(expenses)
+                .where(
+                        memberEq(member.getId()),
+                        currentDateEq(currentDate)
+                )
+                .groupBy(expenses.category.id)
+                .fetch();
+    }
+
+    private BooleanExpression currentDateEq(LocalDate currentDate) {
+        return currentDate != null ? expenses.date.eq(currentDate) : null;
     }
 
     private BooleanExpression isExcluded(BooleanPath excludeFromTotalAmount) {


### PR DESCRIPTION
## 📃 설명

- resolves #15
    - 오늘 지출 안내 시 오늘 `지출한 총액`과 `카테고리 별 지출 총액`, `지출 비율`을 반환
    - `지출 비율`
        - `지출 총액` 기준 오늘 지출 가능한 금액 대비 실제 쓴 지출의 비율
        - 소수점 첫 째 자리에서 반올림

## 🔨 작업 내용

1. 오늘 지출 안내 API 구현
2. 지출 추천 로직과 겹치는 코드를 리팩토링
3. 예산이 없을 경우 예외처리 추가


## 💬 기타 사항
- 요청 성공 예
<img width="700" alt="스크린샷 2023-12-01 오전 11 18 07" src="https://github.com/Wanted-Pre-Onboarding-Backend7-R/spend-tracker/assets/110372498/75ccea7f-2e52-4b97-a215-aee3fb2eedbe">

